### PR TITLE
Improve test coverage config and validate adapter/service unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,12 @@ markers = [
 
 [tool.coverage.run]
 source = ["src"]
-omit = ["*/tests/*", "*/__main__.py"]
+omit = [
+    "*/tests/*",                
+    "*/__main__.py",            
+    "src/mail_client_service_client/*", # Auto-generated OpenAPI client, tested indirectly
+]
+
 
 [tool.coverage.report]
 fail_under = 85 # Justification: A high threshold ensures most code is tested.

--- a/src/mail_client_service/tests/test_client_impl.py
+++ b/src/mail_client_service/tests/test_client_impl.py
@@ -1,0 +1,111 @@
+import pytest
+from mail_client_service_client.models import (
+    MessageSummary,
+    MessageDetail,
+)
+from mail_client_service_client.api.default import (
+    get_messages_messages_get,
+    get_message_messages_message_id_get,
+    delete_message_messages_message_id_delete,
+    mark_message_as_read_messages_message_id_mark_as_read_post,
+)
+
+# Import the ServiceClient from mail_client_adapter
+from mail_client_adapter.client_impl import ServiceClient
+
+
+def test_get_messages_calls_generated_client(monkeypatch):
+    mock_resp = [
+        MessageSummary(
+            id="1",
+            from_="a@test.com",
+            to=["b@test.com"],
+            date="2024-01-01",
+            subject="Hi",
+        )
+    ]
+    monkeypatch.setattr(
+        get_messages_messages_get, "sync",
+        lambda client, max_results: mock_resp
+    )
+
+    svc = ServiceClient()
+    resp = svc.get_messages(max_results=5)
+
+    assert isinstance(resp, list)
+    assert isinstance(resp[0], MessageSummary)
+    assert resp[0].subject == "Hi"
+
+
+def test_get_message_calls_generated_client(monkeypatch):
+    mock_resp = MessageDetail(
+        id="123",
+        from_="a@test.com",
+        to=["b@test.com"],
+        date="2024-01-01",
+        subject="Hello",
+        body="This is a test message",
+    )
+    monkeypatch.setattr(
+        get_message_messages_message_id_get, "sync",
+        lambda client, message_id: mock_resp
+    )
+
+    svc = ServiceClient()
+    resp = svc.get_message("123")
+
+    assert isinstance(resp, MessageDetail)
+    assert resp.id == "123"
+    assert resp.subject == "Hello"
+
+
+def test_delete_message_returns_true_on_ok(monkeypatch):
+    class FakeResp:
+        status = "ok"
+
+    monkeypatch.setattr(
+        delete_message_messages_message_id_delete, "sync",
+        lambda client, message_id: FakeResp()
+    )
+
+    svc = ServiceClient()
+    assert svc.delete_message("123") is True
+
+
+def test_delete_message_returns_false_on_fail(monkeypatch):
+    class FakeResp:
+        status = "error"
+
+    monkeypatch.setattr(
+        delete_message_messages_message_id_delete, "sync",
+        lambda client, message_id: FakeResp()
+    )
+
+    svc = ServiceClient()
+    assert svc.delete_message("123") is False
+
+
+def test_mark_as_read_returns_true_on_ok(monkeypatch):
+    class FakeResp:
+        status = "ok"
+
+    monkeypatch.setattr(
+        mark_message_as_read_messages_message_id_mark_as_read_post, "sync",
+        lambda client, message_id: FakeResp()
+    )
+
+    svc = ServiceClient()
+    assert svc.mark_as_read("123") is True
+
+
+def test_mark_as_read_returns_false_on_fail(monkeypatch):
+    class FakeResp:
+        status = "error"
+
+    monkeypatch.setattr(
+        mark_message_as_read_messages_message_id_mark_as_read_post, "sync",
+        lambda client, message_id: FakeResp()
+    )
+
+    svc = ServiceClient()
+    assert svc.mark_as_read("123") is False


### PR DESCRIPTION
# Pull Request

## Summary
- Added **mail_client_adapter** implementation to bridge between the generated service client and the abstract `mail_client_api`.
- Implemented **unit tests** for the adapter and service layer (`mail_client_service`), ensuring correct delegation to the generated client.
- Updated **coverage configuration** to omit auto-generated code (e.g., OpenAPI client, tests), so coverage reflects only hand-written logic.
- Verified that all `mail_client_service` tests pass locally with >90% coverage.  
- Deferred E2E and integration test fixes (they require live Gmail credentials and running service).

## Related Issues
- Closes #
- Relates to ongoing Part 3 task in OSS-NML assignment

## Change Type
- [ ] 🐛 Bug fix  
- [x] ✨ Feature / enhancement  
- [ ] 💥 Breaking change  
- [ ] 📚 Documentation  
- [x] 🔧 Refactor / cleanup  
- [ ] ⚡ Performance  
- [x] 🧪 Test improvement  
- [ ] 🔨 Build / tooling  

## Impacted Areas
- [x] `mail_client_api`  
- [x] `gmail_client_impl` (indirectly via adapter integration)  
- [ ] Documentation  
- [x] Tests  
- [ ] Tooling / CI  
- [ ] Other (describe in summary)  

## Testing
### Commands executed
```bash
uv run pytest src/mail_client_service/tests -v
uv run pytest --maxfail=1 --disable-warnings -q
uv run ruff check .
uv run mypy src


### Results
- [x] Tests pass (unit tests for adapter + service)  
- [x] Type checks clean  
- [x] Linting clean  
- [ ] Manual verification (integration/E2E tests pending valid credentials + running service)  

## Quality Checklist
- [x] Contract boundaries respected; abstractions unchanged unless noted  
- [x] Backward compatibility confirmed or migration documented  
- [x] Security / secrets handled correctly  
- [x] Performance impact acceptable  
- [ ] Docs updated for user-facing changes  

## Breaking Changes (skip if none)
None  

## Notes for Reviewers
- Coverage config updated to exclude generated client code (`mail_client_service_client`)  
- Only adapter + service unit tests verified locally; integration and E2E require valid Gmail credentials and running FastAPI service  
- No API or abstraction changes introduced in this PR  
