### PR TITLE
Hw3 update telemetry discord changes

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,24 +2,20 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# FIX 1: Pin OpenAI to 2.9.0 to match your uv.lock
-# FIX 2: Install python-multipart (often needed) and other deps
-RUN pip install --no-cache-dir \
-    fastapi \
-    uvicorn \
-    prometheus-fastapi-instrumentator \
-    openai==2.9.0 \
-    httpx \
-    python-dotenv \
-    python-multipart
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
-# Copy the source code
+RUN pip install --no-cache-dir uv
+
+COPY pyproject.toml uv.lock ./
 COPY src/ ./src/
 
-# FIX 3: COMPLEX PYTHONPATH
-# Your code uses nested src folders (e.g., src/ai_api/src).
-# We must add EACH component's inner 'src' folder to the path so imports work.
-ENV PYTHONPATH="${PYTHONPATH}:/app/src/ai_service/src:/app/src/ai_api/src:/app/src/openai_impl/src:/app/src/ai_ticket_service/src"
+RUN uv sync --frozen
 
-# CRITICAL CHANGE: Launch the integrated service
-CMD ["uvicorn", "ai_ticket_service.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+RUN uv pip install --python .venv/bin/python -e src/ai_ticket_service
+
+# Runtime-only google deps
+RUN uv pip install --python .venv/bin/python \
+    google-api-python-client google-auth google-auth-oauthlib
+
+CMD ["uv", "run", "uvicorn", "ai_ticket_service.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -25,5 +25,10 @@ services:
     image: grafana/grafana:latest
     ports:
       - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
     depends_on:
       - prometheus
+
+volumes:
+  grafana-storage:

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -2,7 +2,8 @@
 global:
   scrape_interval: 5s
 
+# deploy/prometheus.yml
 scrape_configs:
-  - job_name: "ai_service"
+  - job_name: "ai_ticket_service" 
     static_configs:
       - targets: ["ai_service:8000"]

--- a/src/ai_ticket_service/src/ai_ticket_service/main.py
+++ b/src/ai_ticket_service/src/ai_ticket_service/main.py
@@ -26,13 +26,13 @@ from ai_ticket_service.models import (
 )
 from tickets_api import Ticket, TicketInterface, TicketStatus
 from tickets_client_impl import TicketsClient  # Import at module level for integration tests
-
+from prometheus_fastapi_instrumentator import Instrumentator
 app = FastAPI(
     title="AI Ticket Orchestration Service",
     description="Natural language to ticket actions via AI + ticket client",
     version="0.1.0",
 )
-
+Instrumentator().instrument(app).expose(app)
 load_dotenv()
 logger = logging.getLogger(__name__)
 DEFAULT_SYSTEM_PROMPT = "You are a strict router that extracts intent, title, description."

--- a/src/ai_ticket_service/src/ai_ticket_service/main.py
+++ b/src/ai_ticket_service/src/ai_ticket_service/main.py
@@ -10,6 +10,7 @@ import uvicorn
 from chat_client_api.client import ChatInterface
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
+from prometheus_fastapi_instrumentator import Instrumentator
 from trello_client_impl.oauth import TrelloOAuthHandler  # type: ignore[import-untyped]
 from trello_ticket_impl.trello_ticket_impl import TrelloTicketClientImpl  # type: ignore[import-untyped]
 
@@ -26,7 +27,7 @@ from ai_ticket_service.models import (
 )
 from tickets_api import Ticket, TicketInterface, TicketStatus
 from tickets_client_impl import TicketsClient  # Import at module level for integration tests
-from prometheus_fastapi_instrumentator import Instrumentator
+
 app = FastAPI(
     title="AI Ticket Orchestration Service",
     description="Natural language to ticket actions via AI + ticket client",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,9 +28,10 @@ resource "aws_key_pair" "generated_key" {
   public_key = tls_private_key.pk.public_key_openssh
 }
 
+# FIX: Moved the filename to /tmp/ to avoid leaking it in the repo path per peer review
 resource "local_file" "ssh_key" {
   content         = tls_private_key.pk.private_key_pem
-  filename        = "${path.module}/hw3-key-free-tier.pem"
+  filename        = "/tmp/hw3-key-free-tier.pem" 
   file_permission = "0400"
 }
 
@@ -107,7 +108,7 @@ resource "aws_instance" "server" {
               apt-get update
               apt-get install -y docker.io docker-compose-v2 git
 
-              # 3. Clone Repo (CRITICAL CHANGE: Targeting the final branch)
+              # 3. Clone Repo (Targeting the final working branch)
               cd /home/ubuntu
               git clone --branch hw_3_final_submission_working_discord https://github.com/natashagit/oss-nml.git app
 
@@ -126,6 +127,7 @@ output "grafana_url" {
   value = "http://${aws_instance.server.public_ip}:3000"
 }
 
+# FIX: Updated output to reflect new secure path
 output "ssh_command" {
-  value = "ssh -i hw3-key-free-tier.pem ubuntu@${aws_instance.server.public_ip}"
+  value = "ssh -i /tmp/hw3-key-free-tier.pem ubuntu@${aws_instance.server.public_ip}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -107,9 +107,9 @@ resource "aws_instance" "server" {
               apt-get update
               apt-get install -y docker.io docker-compose-v2 git
 
-              # 3. Clone Repo (Pointing to the final, integrated branch)
+              # 3. Clone Repo (CRITICAL CHANGE: Targeting the final branch)
               cd /home/ubuntu
-              git clone --branch hw_3_second_submission https://github.com/natashagit/oss-nml.git app
+              git clone --branch hw_3_final_submission_working_discord https://github.com/natashagit/oss-nml.git app
 
               # 4. Permissions
               chown -R ubuntu:ubuntu /home/ubuntu/app


### PR DESCRIPTION
Editable Installs: Per @ttgannon's feedback, I removed the brittle manual PYTHONPATH logic from the Dockerfile and replaced it with uv pip install -e, which handles package layout much more reliably.

Security: Moved the SSH private key generation path to /tmp/ to ensure no sensitive material is saved within the module directory.

Persistence: Added a named volume grafana-storage to the docker-compose.yml to address the concern regarding data loss on container restart.